### PR TITLE
Change hamming test to throw an exception for different strand lengths

### DIFF
--- a/hamming/src/test/java/HammingTest.java
+++ b/hamming/src/test/java/HammingTest.java
@@ -30,14 +30,14 @@ public class HammingTest {
         assertThat(Hamming.compute("GGACG", "GGTCG"), is(1));
     }
 
-    @Test
-    public void testIgnoresExtraLengthOnFirstStrandWhenLonger() {
-        assertThat(Hamming.compute("AAAG", "AAA"), is(0));
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidatesFirstStrandNotLonger() {
+        Hamming.compute("AAAG", "AAA");
     }
 
-    @Test
-    public void testIgnoresExtraLengthOnOtherStrandWhenLonger() {
-        assertThat(Hamming.compute("AAA", "AAAG"), is(0));
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidatesOtherStrandNotLonger() {
+        Hamming.compute("AAA", "AAAG");
     }
 
     @Test


### PR DESCRIPTION
For issue [#12 Make Hamming conform to official definition](https://github.com/exercism/xjava/issues/12).

The hamming distance is undefined for strings of different lengths, so throw an InvalidArgumentException if either strand is longer.