### PR TITLE
scrabble-score: replace illegal word

### DIFF
--- a/scrabble-score/src/test/java/ScrabbleScoreTest.java
+++ b/scrabble-score/src/test/java/ScrabbleScoreTest.java
@@ -23,7 +23,7 @@ public class ScrabbleScoreTest {
                 {"f", 4},
                 {"street", 6},
                 {"quirky", 22},
-                {"MULTIBILLIONAIRE", 20},
+                {"oxyphenbutazone", 41},
                 {"alacrity", 13},
         });
     }


### PR DESCRIPTION
multibillionaire can't be played as a word in a real scrabble game. See https://github.com/exercism/x-common/issues/86