### PR TITLE
Corrected error in RandonKeyCipherTest.java

### DIFF
--- a/simple-cipher/src/test/java/RandomKeyCipherTest.java
+++ b/simple-cipher/src/test/java/RandomKeyCipherTest.java
@@ -25,7 +25,7 @@ public class RandomKeyCipherTest {
 
     @Test
     public void cipherKeysAreRandomlyGenerated() {
-        assertTrue(!(new Cipher().getKey().equals(cipher.getKey().length())));
+        assertTrue(!(new Cipher().getKey().equals(cipher.getKey())));
     }
 
     /**


### PR DESCRIPTION
I changed the cipherKeysAreRandomlyGenerated test so that it does not compare the new Cipher to the length of the old Cipher.