### PR TITLE
crypto-square: Fix invalid tests

### DIFF
--- a/crypto-square/src/example/java/Crypto.java
+++ b/crypto-square/src/example/java/Crypto.java
@@ -51,6 +51,10 @@ public class Crypto {
     }
 
     public String getCipherText() {
+        return getNormalizedCipherText().replaceAll("\\s", "");
+    }
+
+    public String getNormalizedCipherText() {
         StringBuilder cipherText = new StringBuilder(normalizedPlaintext.length());
 
         for (int index = 0; index < squareSize; index++) {
@@ -59,14 +63,12 @@ public class Crypto {
                     cipherText.append(segment.charAt(index));
                 }
             }
+
+            if (index < squareSize - 1) {
+                cipherText.append(" ");
+            }
         }
 
         return cipherText.toString();
-    }
-
-    public String getNormalizedCipherText() {
-        String cipher = getCipherText();
-
-        return String.join(" ", getSegmentText(cipher, squareSize - 1));
     }
 }

--- a/crypto-square/src/test/java/CryptoSquareTest.java
+++ b/crypto-square/src/test/java/CryptoSquareTest.java
@@ -106,7 +106,7 @@ public class CryptoSquareTest {
     @Test
     public void normalizedCipherNotExactlyDivisibleBy5SpillsIntoSmallerSegment() {
         Crypto crypto = new Crypto("Madness, and then illumination.");
-        String expectedOutput = "msemo aanin dninn dlaet ltshu i";
+        String expectedOutput = "msemo aanin dnin ndla etlt shui";
 
         assertEquals(expectedOutput, crypto.getNormalizedCipherText());
     }
@@ -114,7 +114,7 @@ public class CryptoSquareTest {
     @Test
     public void normalizedCipherIsSplitIntoSegmentsOfCorrectSize() {
         Crypto crypto = new Crypto("If man was meant to stay on the ground god would have given us roots");
-        String expectedOutput = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghns seoau";
+        String expectedOutput = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau";
 
         assertEquals(expectedOutput, crypto.getNormalizedCipherText());
     }


### PR DESCRIPTION
The existing tests were normalizing the strings based on the square size and not the actual sequence of characters from the columns.
You can refer to the source material where "If man was meant to stay on the 
ground god would have given us roots" should be "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau" but were grouped by square size on the existing tests. This is a temporary fix until #55 uses the json file.