### PR TITLE
Atbash-Cipher: build.gradle is empty

### DIFF
--- a/atbash-cipher/build.gradle
+++ b/atbash-cipher/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: "java"
+apply plugin: "eclipse"
+apply plugin: "idea"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile "junit:junit:4.10"
+}


### PR DESCRIPTION
* Provide a valid build.gradle for atbash-cipher exercise
* Close #81 