### PR TITLE
Initial POC of how to ignore all-but-first test

### DIFF
--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -19,4 +19,11 @@ subprojects { project ->
       println "  (source = " + compileTask.source.asPath + ")"
     }
   }
+
+  task fullTest(type: Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = "Runs tests without exclusions."
+  }
+
+  check.dependsOn(fullTest)
 }

--- a/exercises/grade-school/build.gradle
+++ b/exercises/grade-school/build.gradle
@@ -11,3 +11,8 @@ dependencies {
   testCompile "org.assertj:assertj-core:3.2.0"
 }
 
+test {
+    useJUnit {
+        excludeCategories 'io.exercism.xjava.NotReady'
+    }
+}

--- a/exercises/grade-school/src/example/java/io/exercism/xjava/NotReady.java
+++ b/exercises/grade-school/src/example/java/io/exercism/xjava/NotReady.java
@@ -1,0 +1,8 @@
+package io.exercism.xjava;
+
+/**
+ * Marker interface used to exclude tests as you work
+ * through each exercise.
+ */
+public interface NotReady {
+}

--- a/exercises/grade-school/src/test/java/SchoolTest.java
+++ b/exercises/grade-school/src/test/java/SchoolTest.java
@@ -1,5 +1,7 @@
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.exercism.xjava.NotReady;
+import org.junit.experimental.categories.Category;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -16,12 +18,14 @@ public class SchoolTest {
   }
 
   @Test
+  @Category(NotReady.class)
   public void addsStudents() {
     school.add("Aimee", 2);
     assertThat(school.db().get(2)).contains("Aimee");
   }
 
   @Test
+  @Category(NotReady.class)
   public void addsMoreStudentsInSameGrade() {
     final int grade = 2;
     school.add("James", grade);
@@ -32,6 +36,7 @@ public class SchoolTest {
   }
 
   @Test
+  @Category(NotReady.class)
   public void addsStudentsInMultipleGrades() {
     school.add("Chelsea", 3);
     school.add("Logan", 7);
@@ -42,6 +47,7 @@ public class SchoolTest {
   }
 
   @Test
+  @Category(NotReady.class)
   public void getsStudentsInAGrade() {
     school.add("Franklin", 5);
     school.add("Bradley", 5);
@@ -50,11 +56,13 @@ public class SchoolTest {
   }
 
   @Test
+  @Category(NotReady.class)
   public void getsStudentsInEmptyGrade() {
     assertThat(school.grade(1)).isEmpty();
   }
 
   @Test
+  @Category(NotReady.class)
   public void sortsSchool() {
     school.add("Jennifer", 4);
     school.add("Kareem", 6);


### PR DESCRIPTION
Introduce a new JUnit test category that lets us mark certain tests as
not ready for execution. The test task in the individual project
can then be configured to not run tests marked as `NotReady`.

For the CI server builds, add a fullTest test task that simply runs
tests as normal, and link it into the check task so it runs on builds.

This is not perfect, as the class under test must still compile, so it
must have at least the correct signatures of all the methods tested.
Also, it may be worth finding a way to distribute the NotReady interface
that doesn't require checking it into every project.

This will fix #101.