### PR TITLE
Remove Guava and use JUnit assert

### DIFF
--- a/exercises/etl/src/test/java/EtlTest.java
+++ b/exercises/etl/src/test/java/EtlTest.java
@@ -22,7 +22,7 @@ public class EtlTest {
                 put("a", 1);
             }
         };
-        Collections.unmodifiableMap(expected);
+        expected = Collections.unmodifiableMap(expected);
 
         assertEquals(etl.transform(old), expected);
     }
@@ -45,7 +45,7 @@ public class EtlTest {
                 put("u", 1);
             }
         };
-        Collections.unmodifiableMap(expected);
+        expected = Collections.unmodifiableMap(expected);
 
         assertEquals(etl.transform(old), expected);
     }
@@ -68,7 +68,7 @@ public class EtlTest {
                 put("g", 2);
             }
         };
-        Collections.unmodifiableMap(expected);
+        expected = Collections.unmodifiableMap(expected);
 
         assertEquals(etl.transform(old), expected);
     }
@@ -118,7 +118,7 @@ public class EtlTest {
                 put("z", 10);
             }
         };
-        Collections.unmodifiableMap(expected);
+        expected = Collections.unmodifiableMap(expected);
 
         assertEquals(etl.transform(old), expected);
     }

--- a/exercises/etl/src/test/java/EtlTest.java
+++ b/exercises/etl/src/test/java/EtlTest.java
@@ -15,7 +15,7 @@ public class EtlTest {
                 put(1, Arrays.asList("A"));
             }
         };
-        Collections.unmodifiableMap(old);
+        old = Collections.unmodifiableMap(old);
 
         Map<String, Integer> expected = new HashMap<String, Integer>() {
             {
@@ -34,7 +34,7 @@ public class EtlTest {
                 put(1, Arrays.asList("A", "E", "I", "O", "U"));
             }
         };
-        Collections.unmodifiableMap(old);
+        old = Collections.unmodifiableMap(old);
 
         Map<String, Integer> expected = new HashMap<String, Integer>() {
             {
@@ -58,7 +58,7 @@ public class EtlTest {
                 put(2, Arrays.asList("D", "G"));
             }
         };
-        Collections.unmodifiableMap(old);
+        old = Collections.unmodifiableMap(old);
 
         Map<String, Integer> expected = new HashMap<String, Integer>() {
             {
@@ -86,7 +86,7 @@ public class EtlTest {
                 put(10, Arrays.asList("Q", "Z"));
             }
         };
-        Collections.unmodifiableMap(old);
+        old = Collections.unmodifiableMap(old);
 
         Map<String, Integer> expected = new HashMap<String, Integer>() {
             {

--- a/exercises/etl/src/test/java/EtlTest.java
+++ b/exercises/etl/src/test/java/EtlTest.java
@@ -1,79 +1,125 @@
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
-import org.junit.Ignore;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 
 public class EtlTest {
     private final Etl etl = new Etl();
 
-
     @Test
     public void testTransformOneValue() {
-        Map<Integer, List<String>> old = ImmutableMap.of(1, Arrays.asList("A"));
-        Map<String, Integer> expected = ImmutableMap.of("a", 1);
+        Map<Integer, List<String>> old = new HashMap<Integer, List<String>>() {
+            {
+                put(1, Arrays.asList("A"));
+            }
+        };
+        Collections.unmodifiableMap(old);
 
-        assertThat(etl.transform(old)).isEqualTo(expected);
+        Map<String, Integer> expected = new HashMap<String, Integer>() {
+            {
+                put("a", 1);
+            }
+        };
+        Collections.unmodifiableMap(expected);
+
+        assertEquals(etl.transform(old), expected);
     }
 
-    @Ignore
     @Test
     public void testTransformMoreValues() {
-        Map<Integer, List<String>> old = ImmutableMap.of(
-                1, Arrays.asList("A", "E", "I", "O", "U")
-        );
-        Map<String, Integer> expected = ImmutableMap.of(
-                "a", 1,
-                "e", 1,
-                "i", 1,
-                "o", 1,
-                "u", 1
-        );
+        Map<Integer, List<String>> old = new HashMap<Integer, List<String>>() {
+            {
+                put(1, Arrays.asList("A", "E", "I", "O", "U"));
+            }
+        };
+        Collections.unmodifiableMap(old);
 
-        assertThat(etl.transform(old)).isEqualTo(expected);
+        Map<String, Integer> expected = new HashMap<String, Integer>() {
+            {
+                put("a", 1);
+                put("e", 1);
+                put("i", 1);
+                put("o", 1);
+                put("u", 1);
+            }
+        };
+        Collections.unmodifiableMap(expected);
+
+        assertEquals(etl.transform(old), expected);
     }
 
-    @Ignore
     @Test
     public void testMoreKeys() {
-        Map<Integer, List<String>> old = ImmutableMap.of(
-                1, Arrays.asList("A", "E"),
-                2, Arrays.asList("D", "G")
-        );
-        Map<String, Integer> expected = ImmutableMap.of(
-                "a", 1,
-                "e", 1,
-                "d", 2,
-                "g", 2
-        );
+        Map<Integer, List<String>> old = new HashMap<Integer, List<String>>() {
+            {
+                put(1, Arrays.asList("A", "E"));
+                put(2, Arrays.asList("D", "G"));
+            }
+        };
+        Collections.unmodifiableMap(old);
 
-        assertThat(etl.transform(old)).isEqualTo(expected);
+        Map<String, Integer> expected = new HashMap<String, Integer>() {
+            {
+                put("a", 1);
+                put("e", 1);
+                put("d", 2);
+                put("g", 2);
+            }
+        };
+        Collections.unmodifiableMap(expected);
+
+        assertEquals(etl.transform(old), expected);
     }
 
-    @Ignore
     @Test
     public void testFullDataset() {
-        Map<Integer, List<String>> old = ImmutableMap.<Integer, List<String>>builder().
-                put(1, Arrays.asList("A", "E", "I", "O", "U", "L", "N", "R", "S", "T")).
-                put(2, Arrays.asList("D", "G")).
-                put(3, Arrays.asList("B", "C", "M", "P")).
-                put(4, Arrays.asList("F", "H", "V", "W", "Y")).
-                put(5, Arrays.asList("K")).
-                put(8, Arrays.asList("J", "X")).
-                put(10, Arrays.asList("Q", "Z")).
-                build();
-        Map<String, Integer> expected = ImmutableMap.<String, Integer>builder().
-                put("a", 1).put("b", 3).put("c", 3).put("d", 2).put("e", 1).
-                put("f", 4).put("g", 2).put("h", 4).put("i", 1).put("j", 8).
-                put("k", 5).put("l", 1).put("m", 3).put("n", 1).put("o", 1).
-                put("p", 3).put("q", 10).put("r", 1).put("s", 1).put("t", 1).
-                put("u", 1).put("v", 4).put("w", 4).put("x", 8).put("y", 4).
-                put("z", 10).build();
+        Map<Integer, List<String>> old = new HashMap<Integer, List<String>>() {
+            {
+                put(1, Arrays.asList("A", "E", "I", "O", "U", "L", "N", "R", "S", "T"));
+                put(2, Arrays.asList("D", "G"));
+                put(3, Arrays.asList("B", "C", "M", "P"));
+                put(4, Arrays.asList("F", "H", "V", "W", "Y"));
+                put(5, Arrays.asList("K"));
+                put(8, Arrays.asList("J", "X"));
+                put(10, Arrays.asList("Q", "Z"));
+            }
+        };
+        Collections.unmodifiableMap(old);
 
-        assertThat(etl.transform(old)).isEqualTo(expected);
+        Map<String, Integer> expected = new HashMap<String, Integer>() {
+            {
+                put("a", 1);
+                put("b", 3);
+                put("c", 3);
+                put("d", 2);
+                put("e", 1);
+                put("f", 4);
+                put("g", 2);
+                put("h", 4);
+                put("i", 1);
+                put("j", 8);
+                put("k", 5);
+                put("l", 1);
+                put("m", 3);
+                put("n", 1);
+                put("o", 1);
+                put("p", 3);
+                put("q", 10);
+                put("r", 1);
+                put("s", 1);
+                put("t", 1);
+                put("u", 1);
+                put("v", 4);
+                put("w", 4);
+                put("x", 8);
+                put("y", 4);
+                put("z", 10);
+            }
+        };
+        Collections.unmodifiableMap(expected);
+
+        assertEquals(etl.transform(old), expected);
     }
 }


### PR DESCRIPTION
As described in issue #168, I removed the dependency from Guava library in order to use `Collections.unmodifiableMap` from the standard library. The last test case is longer than before, but at least now all the test cases are written coherently and so they are easier to understand.

Also, I noticed that this exercise was using the Guava assertions `assertJ`. So I removed it and used the standard `assertEquals` from JUnit (though, I could have used the Hamcrest library for the `assertThat`, or the `assertThat` from JUnit + a matcher from Hamcrest. Let me know if you prefer that way for the assertion instead of the standard assertEqual).
