### PR TITLE
all-your-base: add to track

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,7 +53,8 @@
     "bracket-push",
     "pythagorean-triplet",
     "binary-search-tree",
-    "binary-search"
+    "binary-search",
+    "all-your-base"
   ],
   "exercises": [
     {
@@ -303,6 +304,11 @@
     },
     {
       "slug": "binary-search",
+      "difficulty": 1,
+      "topics": []
+    },
+    {
+      "slug": "all-your-base",
       "difficulty": 1,
       "topics": []
     }

--- a/exercises/all-your-base/build.gradle
+++ b/exercises/all-your-base/build.gradle
@@ -1,0 +1,17 @@
+apply plugin: "java"
+apply plugin: "eclipse"
+apply plugin: "idea"
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  testCompile "junit:junit:4.12"
+}
+test {
+  testLogging {
+    exceptionFormat = 'full'
+    events = ["passed", "failed", "skipped"]
+  }
+}

--- a/exercises/all-your-base/src/example/java/BaseConverter.java
+++ b/exercises/all-your-base/src/example/java/BaseConverter.java
@@ -1,0 +1,80 @@
+import java.util.Arrays;
+
+final class BaseConverter {
+
+    private static final int MINIMUM_VALID_BASE = 2;
+
+    private static final String INVALID_BASE_ERROR_MESSAGE = "Bases must be at least 2.";
+
+    private final int numeral;
+
+    BaseConverter(final int originalBase, final int[] originalDigits) {
+        validateInputs(originalBase, originalDigits);
+        this.numeral = computeNumeral(originalBase, originalDigits);
+    }
+
+    int[] convertToBase(final int newBase) {
+        if (newBase < MINIMUM_VALID_BASE) {
+            throw new IllegalArgumentException(INVALID_BASE_ERROR_MESSAGE);
+        }
+
+        final int largestExponent = computeLargestExponentForBase(newBase);
+        final int[] result = new int[largestExponent + 1];
+        int remainder = numeral;
+
+        for (int currentExponent = largestExponent; currentExponent >= 0; currentExponent--) {
+            final int coefficient = (int) Math.floor(remainder / Math.pow(newBase, currentExponent));
+
+            result[largestExponent - currentExponent] = coefficient;
+
+            remainder -= coefficient * Math.pow(newBase, currentExponent);
+        }
+
+        return result;
+    }
+
+    private void validateInputs(final int originalBase, final int[] originalDigits) {
+        if (originalBase < MINIMUM_VALID_BASE) {
+            throw new IllegalArgumentException(INVALID_BASE_ERROR_MESSAGE);
+        }
+
+        if (originalDigits.length == 0) {
+            throw new IllegalArgumentException("You must supply at least one digit.");
+        }
+
+        if (originalDigits.length > 1 && originalDigits[0] == 0) {
+            throw new IllegalArgumentException("Digits may not contain leading zeros.");
+        }
+
+        if (Arrays.stream(originalDigits).min().getAsInt() < 0) {
+            throw new IllegalArgumentException("Digits may not be negative.");
+        }
+
+        if (Arrays.stream(originalDigits).max().getAsInt() >= originalBase) {
+            throw new IllegalArgumentException("All digits must be strictly less than the base.");
+        }
+    }
+
+    private int computeNumeral(final int originalBase, final int[] originalDigits) {
+        int result = 0;
+
+        final int largestExponent = originalDigits.length - 1;
+
+        for (int currentExponent = largestExponent; currentExponent >= 0; currentExponent--) {
+            result += originalDigits[largestExponent - currentExponent] * Math.pow(originalBase, currentExponent);
+        }
+
+        return result;
+    }
+
+    private int computeLargestExponentForBase(final int newBase) {
+        int result = 0;
+
+        while (Math.pow(newBase, result + 1) < numeral) {
+            result += 1;
+        }
+
+        return result;
+    }
+
+}

--- a/exercises/all-your-base/src/main/java/BaseConverter.java
+++ b/exercises/all-your-base/src/main/java/BaseConverter.java
@@ -1,0 +1,5 @@
+final class BaseConverter {
+
+
+
+}

--- a/exercises/all-your-base/src/test/java/BaseConverterTest.java
+++ b/exercises/all-your-base/src/test/java/BaseConverterTest.java
@@ -1,0 +1,256 @@
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public final class BaseConverterTest {
+
+    /*
+     * See https://github.com/junit-team/junit4/wiki/Rules for information on JUnit Rules in general and
+     * ExpectedExceptions in particular.
+     */
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testSingleBitOneToDecimal() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1});
+
+        final int[] expectedDigits = new int[]{1};
+        final int[] actualDigits = baseConverter.convertToBase(10);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testBinaryToSingleDecimal() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1});
+
+        final int[] expectedDigits = new int[]{5};
+        final int[] actualDigits = baseConverter.convertToBase(10);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testSingleDecimalToBinary() {
+        final BaseConverter baseConverter = new BaseConverter(10, new int[]{5});
+
+        final int[] expectedDigits = new int[]{1, 0, 1};
+        final int[] actualDigits = baseConverter.convertToBase(2);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testBinaryToMultipleDecimal() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
+
+        final int[] expectedDigits = new int[]{4, 2};
+        final int[] actualDigits = baseConverter.convertToBase(10);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testDecimalToBinary() {
+        final BaseConverter baseConverter = new BaseConverter(10, new int[]{4, 2});
+
+        final int[] expectedDigits = new int[]{1, 0, 1, 0, 1, 0};
+        final int[] actualDigits = baseConverter.convertToBase(2);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testTrinaryToHexadecimal() {
+        final BaseConverter baseConverter = new BaseConverter(3, new int[]{1, 1, 2, 0});
+
+        final int[] expectedDigits = new int[]{2, 10};
+        final int[] actualDigits = baseConverter.convertToBase(16);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testHexadecimalToTrinary() {
+        final BaseConverter baseConverter = new BaseConverter(16, new int[]{2, 10});
+
+        final int[] expectedDigits = new int[]{1, 1, 2, 0};
+        final int[] actualDigits = baseConverter.convertToBase(3);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void test15BitInteger() {
+        final BaseConverter baseConverter = new BaseConverter(97, new int[]{3, 46, 60});
+
+        final int[] expectedDigits = new int[]{6, 10, 45};
+        final int[] actualDigits = baseConverter.convertToBase(73);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testEmptyDigits() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("You must supply at least one digit.");
+
+        new BaseConverter(2, new int[]{});
+    }
+
+    @Test
+    public void testSingleZero() {
+        final BaseConverter baseConverter = new BaseConverter(10, new int[]{0});
+
+        final int[] expectedDigits = new int[]{0};
+        final int[] actualDigits = baseConverter.convertToBase(2);
+
+        assertArrayEquals(
+                String.format(
+                        "Expected digits: %s but found digits: %s",
+                        Arrays.toString(expectedDigits),
+                        Arrays.toString(actualDigits)),
+                expectedDigits,
+                actualDigits);
+    }
+
+    @Test
+    public void testMultipleZeros() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Digits may not contain leading zeros.");
+
+        new BaseConverter(10, new int[]{0, 0, 0});
+    }
+
+    @Test
+    public void testLeadingZeros() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Digits may not contain leading zeros.");
+
+        new BaseConverter(7, new int[]{0, 6, 0});
+    }
+
+    @Test
+    public void testNegativeDigit() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Digits may not be negative.");
+
+        new BaseConverter(2, new int[]{1, -1, 1, 0, 1, 0});
+    }
+
+    @Test
+    public void testInvalidPositiveDigit() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("All digits must be strictly less than the base.");
+
+        new BaseConverter(2, new int[]{1, 2, 1, 0, 1, 0});
+    }
+
+    @Test
+    public void testFirstBaseIsOne() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(1, new int[]{});
+    }
+
+    @Test
+    public void testSecondBaseIsOne() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        baseConverter.convertToBase(1);
+    }
+
+    @Test
+    public void testFirstBaseIsZero() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(0, new int[]{});
+    }
+
+    @Test
+    public void testSecondBaseIsZero() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        baseConverter.convertToBase(0);
+    }
+
+    @Test
+    public void testFirstBaseIsNegative() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(-2, new int[]{});
+    }
+
+    @Test
+    public void testSecondBaseIsNegative() {
+        final BaseConverter baseConverter = new BaseConverter(2, new int[]{1});
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        baseConverter.convertToBase(-7);
+    }
+
+}

--- a/exercises/settings.gradle
+++ b/exercises/settings.gradle
@@ -1,5 +1,6 @@
 include 'accumulate'
 include 'acronym'
+include 'all-your-base'
 include 'allergies'
 include 'anagram'
 include 'atbash-cipher'


### PR DESCRIPTION
Canonical data [here](https://github.com/exercism/x-common/blob/master/exercises/all-your-base/canonical-data.json).

The test `both bases are negative` was skipped as it is redundant given the structure of this implementation.

The canonical data also poses some questions for implementors, which I answered as follows:

> What's the canonical representation of zero?

`[0]`

> What representations of zero are allowed?

`[0]`

> Are leading zeroes allowed?

No.

> How should invalid input be handled?

By throwing an exception with an appropriate message.