### PR TITLE
Make Oracle JDK default for Debian distros

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -104,6 +104,7 @@ If you are using Debian or its derivatives (like Ubuntu or Linux Mint), use APT:
    $ sudo add-apt-repository ppa:webupd8team/java
    $ sudo apt-get update
    $ sudo apt-get install oracle-java8-installer
+   $ sudo apt install oracle-java8-set-default
    ```
 -  Install Gradle:
 


### PR DESCRIPTION
Without this instruction, the system continues to use the default OpenJDK.  This is confusing since we instruct the practitioner to install Oracle's JDK.