### PR TITLE
Invoke JUnit assertEquals with Argument Order (expected, actual)

### DIFF
--- a/exercises/etl/src/test/java/EtlTest.java
+++ b/exercises/etl/src/test/java/EtlTest.java
@@ -24,7 +24,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(etl.transform(old), expected);
+        assertEquals(expected, etl.transform(old));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(etl.transform(old), expected);
+        assertEquals(expected, etl.transform(old));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(etl.transform(old), expected);
+        assertEquals(expected, etl.transform(old));
     }
 
     @Test
@@ -120,6 +120,6 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(etl.transform(old), expected);
+        assertEquals(expected, etl.transform(old));
     }
 }


### PR DESCRIPTION
The JUnit API documents assertEquals as taking the expected argument
before the actual argument.  Failure to adhere to this can result in
very confusing test failure messages.

For example in testTransformOneValue 'old' contains 'A' and 'expected'
contains 'a'.  If the implementer does not lower-case the key, the
failure message is as follows if the argument order is
(actual, expected):

EtlTest > testTransformOneValue FAILED
    java.lang.AssertionError: expected:<{A=1}> but was:<{a=1}>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at EtlTest.testTransformOneValue(EtlTest.java:27)

This is very confusing as "was:<{a=1}>" is exactly what we were hoping
the result would be.