### PR TITLE
hello-world: Modify tests to reject `name == ""` comparison

### DIFF
--- a/exercises/hello-world/src/test/java/HelloWorldTest.java
+++ b/exercises/hello-world/src/test/java/HelloWorldTest.java
@@ -8,10 +8,16 @@ public class HelloWorldTest {
 
     @Test
     public void helloNoName() {
-        assertEquals("Hello, World!", HelloWorld.hello(new String("")));
+        assertEquals("Hello, World!", HelloWorld.hello(""));
         assertEquals("Hello, World!", HelloWorld.hello(null));
     }
 
+    @Test
+    @Ignore
+    public void emptyStringIsComparedByValue() {
+        assertEquals("Hello, World!", HelloWorld.hello(new String("")));
+    }
+    
     @Test
     @Ignore
     public void helloSampleName() {

--- a/exercises/hello-world/src/test/java/HelloWorldTest.java
+++ b/exercises/hello-world/src/test/java/HelloWorldTest.java
@@ -8,7 +8,7 @@ public class HelloWorldTest {
 
     @Test
     public void helloNoName() {
-        assertEquals("Hello, World!", HelloWorld.hello(""));
+        assertEquals("Hello, World!", HelloWorld.hello(new String("")));
         assertEquals("Hello, World!", HelloWorld.hello(null));
     }
 


### PR DESCRIPTION
Hello World was not supposed to be tricky, but I think I've found an uncovered case.

In some solutions people were using `name == ""` to check for empty string, as opposed to `name.equals("")`. The `==` operator in java compares object references, not values. Currently the tests pass in such case, but it's only a coincidence, since they compare to the same instance of the String constant `""` in JVM's constant pool. For newcomers, it could be a dangerous misconception. This change avoids it.

It's my first PR, so any feedback and guidance is welcome.

I've also considered making a separate test case instead of changing current one, to clarify the problem. Do you think that would be better?
