### PR TITLE
Change order and names of anagram tests

### DIFF
--- a/exercises/anagram/src/test/java/AnagramTest.java
+++ b/exercises/anagram/src/test/java/AnagramTest.java
@@ -18,11 +18,19 @@ public class AnagramTest {
 
     @Ignore
     @Test
-    public void testSimpleAnagram() {
+    public void testDetectSimpleAnagram() {
         Anagram detector = new Anagram("ant");
         List<String> anagram = detector.match(Arrays.asList("tan", "stand", "at"));
         assertThat(anagram, hasItem("tan"));
         assertThat(anagram.size(), is(1));
+    }
+
+    @Ignore
+    @Test
+    public void testDetectLongerAnagram() {
+        Anagram detector = new Anagram("listen");
+        List<String> anagrams = detector.match(Arrays.asList("enlists", "google", "inlets", "banana"));
+        assertThat(anagrams, hasItem("inlets"));
     }
 
     @Ignore
@@ -35,10 +43,17 @@ public class AnagramTest {
 
     @Ignore
     @Test
+    public void testDetectMultipleAnagramsForLongerWord() {
+        Anagram detector = new Anagram("allergy");
+        List<String> anagrams = detector.match(Arrays.asList("gallery", "ballerina", "regally", "clergy", "largely", "leading"));
+        assertThat(anagrams, allOf(hasItem("gallery"), hasItem("largely"), hasItem("regally")));
+    }
+
+    @Ignore
+    @Test
     public void testDoesNotConfuseDifferentDuplicates() {
         Anagram detector = new Anagram("galea");
-        List<String> anagrams = detector.match(Arrays.asList("eagle"));
-        assertTrue(anagrams.isEmpty());
+        assertTrue(detector.match(Arrays.asList("eagle")).isEmpty());
     }
 
     @Ignore
@@ -48,6 +63,20 @@ public class AnagramTest {
         List<String> anagrams = detector.match(Arrays.asList("corn", "dark", "Corn", "rank", "CORN", "cron", "park"));
         assertThat(anagrams, hasItem("cron"));
         assertThat(anagrams.size(), is(1));
+    }
+
+    @Ignore
+    @Test
+    public void testCapitalWordIsNotAnagram() {
+        Anagram detector = new Anagram("BANANA");
+        assertTrue(detector.match(Arrays.asList("Banana")).isEmpty());
+    }
+
+    @Ignore
+    @Test
+    public void testIdenticalWordRepeatedIsNotAnagram() {
+        Anagram detector = new Anagram("go");
+        assertTrue(detector.match(Arrays.asList("go Go GO")).isEmpty());
     }
 
     @Ignore
@@ -66,26 +95,25 @@ public class AnagramTest {
 
     @Ignore
     @Test
-    public void testDetectAnagrams() {
-        Anagram detector = new Anagram("listen");
-        List<String> anagrams = detector.match(Arrays.asList("enlists", "google", "inlets", "banana"));
-        assertThat(anagrams, hasItem("inlets"));
-    }
-
-    @Ignore
-    @Test
-    public void testMultipleAnagrams() {
-        Anagram detector = new Anagram("allergy");
-        List<String> anagrams = detector.match(Arrays.asList("gallery", "ballerina", "regally", "clergy", "largely", "leading"));
-        assertThat(anagrams, allOf(hasItem("gallery"), hasItem("largely"), hasItem("regally")));
-    }
-
-    @Ignore
-    @Test
-    public void testAnagramsAreCaseInsensitive() {
+    public void testCaseInsensitiveWhenSubjectStartsWithUpperCaseLetter() {
         Anagram detector = new Anagram("Orchestra");
+        List<String> anagrams = detector.match(Arrays.asList("cashregister", "carthorse", "radishes"));
+        assertThat(anagrams, hasItem("carthorse"));
+    }
+
+    @Ignore
+    @Test
+    public void testCaseInsensitiveWhenAnagramStartsWithUpperCaseLetter() {
+        Anagram detector = new Anagram("orchestra");
         List<String> anagrams = detector.match(Arrays.asList("cashregister", "Carthorse", "radishes"));
         assertThat(anagrams, hasItem("Carthorse"));
     }
 
+    @Ignore
+    @Test
+    public void testCaseInsensitiveWhenBothAnagramAndSubjectStartWithUpperCaseLetter() {
+        Anagram detector = new Anagram("Orchestra");
+        List<String> anagrams = detector.match(Arrays.asList("cashregister", "Carthorse", "radishes"));
+        assertThat(anagrams, hasItem("Carthorse"));
+    }
 }


### PR DESCRIPTION
Changed names of tests to be consistent and changed the order so that similar tests are grouped together. Added more tests using the canonical data. I didn't add tests for everything in the canonical data because some test cases appeared to be redundant. For example, it looks like the "does not detect false positives" test case checks the same thing as "anagrams must use all letters exactly once". However, I'm happy to add tests for every case if people think I should.

See issue #279 for discussion.