### PR TITLE
luhn: fix example solution

### DIFF
--- a/exercises/luhn/src/example/java/LuhnValidator.java
+++ b/exercises/luhn/src/example/java/LuhnValidator.java
@@ -15,7 +15,7 @@ final class LuhnValidator {
         final List<Integer> computedDigits = new ArrayList<>();
 
         for (int charIndex = 0; charIndex < reversedSanitizedCandidate.length(); charIndex++) {
-            int inputDigit = Character.digit(sanitizedCandidate.charAt(charIndex), 10);
+            int inputDigit = Character.digit(reversedSanitizedCandidate.charAt(charIndex), 10);
 
             /*
              * Character.digit returns a negative int if the supplied character does not represent a digit with respect

--- a/exercises/luhn/src/example/java/LuhnValidator.java
+++ b/exercises/luhn/src/example/java/LuhnValidator.java
@@ -9,9 +9,12 @@ final class LuhnValidator {
     boolean isValid(final String candidate) {
         final String sanitizedCandidate = SPACE_PATTERN.matcher(candidate).replaceAll("");
 
+        // We need to alter every second digit counting from the right. Reversing makes this easy!
+        final String reversedSanitizedCandidate = reverse(sanitizedCandidate);
+
         final List<Integer> computedDigits = new ArrayList<>();
 
-        for (int charIndex = 0; charIndex < sanitizedCandidate.length(); charIndex++) {
+        for (int charIndex = 0; charIndex < reversedSanitizedCandidate.length(); charIndex++) {
             int inputDigit = Character.digit(sanitizedCandidate.charAt(charIndex), 10);
 
             /*
@@ -38,6 +41,10 @@ final class LuhnValidator {
 
         final int digitSum = computedDigits.stream().mapToInt(Integer::intValue).sum();
         return digitSum > 0 && digitSum % 10 == 0;
+    }
+
+    private String reverse(final String string) {
+        return new StringBuilder(string).reverse().toString();
     }
 
 }


### PR DESCRIPTION
Previously this code was applying the required operations to every
second digit starting from the LEFT. The correct solution applies the
required operations to every second digit starting from the RIGHT. The
fact that this was not caught by the tests is a problem! The canonical
tests have been updated since this exercise was last overhauled, so next
steps should be to update to match the expanded canonical test suite,
then test against a broken implementation to see if it is now caught.
Even if it is, it may be worth including an explicit left vs right test
in the canonical suite if one does not already exist.