### PR TITLE
Build jq from source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,14 @@ addons:
   apt:
     packages:
       - tree
+
 before_install:
   - rvm install 2.2.5
   - rvm use 2.2.5
+  - bin/build-jq.sh  # we want jq 1.5 features; not avail through pkg repo.
+
+before_script:
+  - export PATH=$TRAVIS_BUILD_DIR/bin:$PATH  # ensure our tools are prefered over included ones.
 
 script:
   - bin/unit-tests.sh

--- a/bin/build-jq.sh
+++ b/bin/build-jq.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+
+pushd bin
+curl --location https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz >jq-1.5.tar.gz
+tar xvf jq-1.5.tar.gz
+cd jq-1.5
+./configure --disable-maintainer-mode && make
+mv jq ..
+popd
+


### PR DESCRIPTION
- we need version 1.5 and can't get it from the official repo.
- includes adjusting the PATH so that our tools (like jq) get
  precedence.