### PR TITLE
rna-transcription: make object-based and add starter implementation

### DIFF
--- a/exercises/rna-transcription/src/example/java/RnaTranscription.java
+++ b/exercises/rna-transcription/src/example/java/RnaTranscription.java
@@ -1,6 +1,6 @@
 public class RnaTranscription {
 
-    public static String ofDna(String strand) {
+    public String ofDna(String strand) {
         StringBuilder sb = new StringBuilder();
         for (char c : strand.toCharArray()) {
             switch (c) {

--- a/exercises/rna-transcription/src/main/java/RnaTranscription.java
+++ b/exercises/rna-transcription/src/main/java/RnaTranscription.java
@@ -1,0 +1,3 @@
+public class RnaTranscription {
+    public String ofDna(String dnaString) { return null; }
+}

--- a/exercises/rna-transcription/src/main/java/RnaTranscription.java
+++ b/exercises/rna-transcription/src/main/java/RnaTranscription.java
@@ -1,3 +1,5 @@
 public class RnaTranscription {
-    public String ofDna(String dnaString) { return null; }
+    public String ofDna(String dnaString) {
+        throw new UnsupportedOperationException("Method has not been implemented yet.");
+    }
 }

--- a/exercises/rna-transcription/src/test/java/RnaTranscriptionTest.java
+++ b/exercises/rna-transcription/src/test/java/RnaTranscriptionTest.java
@@ -1,42 +1,49 @@
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Test;
 
 public class RnaTranscriptionTest {
 
+    private RnaTranscription rnaTranscription;
+
+    @Before
+    public void setUp() {
+        rnaTranscription = new RnaTranscription();
+    }
 
     @Test
     public void testRnaTranscriptionOfEmptyDnaIsEmptyRna() {
-        Assert.assertEquals("", RnaTranscription.ofDna(""));
+        Assert.assertEquals("", rnaTranscription.ofDna(""));
     }
 
     @Ignore
     @Test
     public void testRnaTranscriptionOfCytosineIsGuanine() {
-        Assert.assertEquals("G", RnaTranscription.ofDna("C"));
+        Assert.assertEquals("G", rnaTranscription.ofDna("C"));
     }
 
     @Ignore
     @Test
     public void testRnaTranscriptionOfGuanineIsCytosine() {
-        Assert.assertEquals("C", RnaTranscription.ofDna("G"));
+        Assert.assertEquals("C", rnaTranscription.ofDna("G"));
     }
 
     @Ignore
     @Test
     public void testRnaTranscriptionOfThymineIsAdenine() {
-        Assert.assertEquals("A", RnaTranscription.ofDna("T"));
+        Assert.assertEquals("A", rnaTranscription.ofDna("T"));
     }
 
     @Ignore
     @Test
     public void testRnaTranscriptionOfAdenineIsUracil() {
-        Assert.assertEquals("U", RnaTranscription.ofDna("A"));
+        Assert.assertEquals("U", rnaTranscription.ofDna("A"));
     }
 
     @Ignore
     @Test
     public void testRnaTranscription() {
-        Assert.assertEquals("UGCACCAGAAUU", RnaTranscription.ofDna("ACGTGGTCTTAA"));
+        Assert.assertEquals("UGCACCAGAAUU", rnaTranscription.ofDna("ACGTGGTCTTAA"));
     }
 }


### PR DESCRIPTION
Changed rna-transcription to have an object based implementation (see issue #177) and added starter implementation as it is currently the second exercise in the new ordering (see issue #178).