### PR TITLE
perfect-numbers: update to canonical tests v1.0.0

### DIFF
--- a/exercises/perfect-numbers/src/example/java/NaturalNumber.java
+++ b/exercises/perfect-numbers/src/example/java/NaturalNumber.java
@@ -5,7 +5,7 @@ final class NaturalNumber {
     private final int naturalNumber;
 
     NaturalNumber(int naturalNumber) {
-        if (naturalNumber <= 0) throw new IllegalStateException("Natural numbers are all positive.");
+        if (naturalNumber <= 0) throw new IllegalArgumentException("You must supply a natural number (positive integer)");
         this.naturalNumber = naturalNumber;
     }
 

--- a/exercises/perfect-numbers/src/test/java/NaturalNumberTest.java
+++ b/exercises/perfect-numbers/src/test/java/NaturalNumberTest.java
@@ -1,9 +1,22 @@
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
+/*
+ * version: 1.0.0
+ * https://github.com/exercism/x-common/blob/19d0c7714ce664a1ad762af624c17f8e269fa8b2/exercises/perfect-numbers/canonical-data.json
+ */
 public final class NaturalNumberTest {
+
+    /*
+     * See https://github.com/junit-team/junit4/wiki/Rules for information on JUnit Rules in general and
+     * ExpectedExceptions in particular.
+     */
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testSmallPerfectNumberIsClassifiedCorrectly() {
@@ -31,7 +44,7 @@ public final class NaturalNumberTest {
     @Ignore
     @Test
     public void testMediumAbundantNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.ABUNDANT, new NaturalNumber(24).getClassification());
+        assertEquals(Classification.ABUNDANT, new NaturalNumber(30).getClassification());
     }
 
     @Ignore
@@ -42,20 +55,54 @@ public final class NaturalNumberTest {
 
     @Ignore
     @Test
-    public void testSmallDeficientNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(8).getClassification());
+    public void testSmallestPrimeDeficientNumberIsClassifiedCorrectly() {
+        assertEquals(Classification.DEFICIENT, new NaturalNumber(2).getClassification());
     }
 
     @Ignore
     @Test
-    public void testMediumNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(31).getClassification());
+    public void testSmallestNonPrimeDeficientNumberIsClassifiedCorrectly() {
+        assertEquals(Classification.DEFICIENT, new NaturalNumber(4).getClassification());
+    }
+
+    @Ignore
+    @Test
+    public void testMediumDeficientNumberIsClassifiedCorrectly() {
+        assertEquals(Classification.DEFICIENT, new NaturalNumber(32).getClassification());
     }
 
     @Ignore
     @Test
     public void testLargeDeficientNumberIsClassifiedCorrectly() {
         assertEquals(Classification.DEFICIENT, new NaturalNumber(33550337).getClassification());
+    }
+
+    @Ignore
+    @Test
+    /*
+     * The number 1 has no proper divisors (https://en.wikipedia.org/wiki/Divisor#Further_notions_and_facts), and the
+     * additive identity is 0, so the aliquot sum of 1 should be 0. Hence 1 should be classified as deficient.
+     */
+    public void testThatOneIsCorrectlyClassifiedAsDeficient() {
+        assertEquals(Classification.DEFICIENT, new NaturalNumber(1).getClassification());
+    }
+
+    @Ignore
+    @Test
+    public void testThatNonNegativeIntegerIsRejected() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("You must supply a natural number (positive integer)");
+
+        new NaturalNumber(0);
+    }
+
+    @Ignore
+    @Test
+    public void testThatNegativeIntegerIsRejected() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("You must supply a natural number (positive integer)");
+
+        new NaturalNumber(-1);
     }
 
 }


### PR DESCRIPTION
perfect-numbers [now has canonical data](https://github.com/exercism/x-common/blob/19d0c7714ce664a1ad762af624c17f8e269fa8b2/exercises/perfect-numbers/canonical-data.json). This PR updates the xjava tests to match this new data. Note too the comment at the top of the file which specifies the version of the tests being implemented. Does this seem like a reasonable practice moving forward?