### PR TITLE
Add probot configuration file

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,8 @@
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - "first-timers only"
+  - "good first patch"
+  - "policy"
+
+# Label to use when marking as stale
+staleLabel: stale


### PR DESCRIPTION
Closes #411.

Initial configuration specifies that "first-timers only" and "policy" issues should be exempt from cleanup, and that issues with no activity in the last 60 days should have the (new) [stale label](https://github.com/exercism/xjava/labels/stale) applied. I _think_ the quoted string will work here!

Defaults for non-specified configuration can be found here:

https://github.com/probot/stale#usage