### PR TITLE
Add script to prune extraneous .keep files

### DIFF
--- a/scripts/prune-extra-keep-files.sh
+++ b/scripts/prune-extra-keep-files.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+for EXERCISE_DIRECTORY in $(find exercises -mindepth 2 -maxdepth 2 -type d -name "src"); do
+  STARTER_DIRECTORY="${EXERCISE_DIRECTORY}/main/java"
+  STARTER_FILE_COUNT=$(find "${STARTER_DIRECTORY}" -mindepth 1 -maxdepth 1 -type f -name "*.java" | wc -l)
+  KEEP_FILE_LOCATION="${STARTER_DIRECTORY}/.keep"
+
+  if (( ${STARTER_FILE_COUNT} > 0 )) && [[ -f "${KEEP_FILE_LOCATION}" ]]; then
+    echo "Removing unnecessary keep file ${KEEP_FILE_LOCATION}..."
+    rm "${KEEP_FILE_LOCATION}"
+  fi
+done


### PR DESCRIPTION
**Goal**

Automate removal of extraneous `.keep` files (used to retain practitioner source directories in Git when no explicit `.java` starter files are provided).

**Usage**

From the root of the xjava repository, execute `./scripts/prune-extra-keep-files.sh`