### PR TITLE
Add central policies document

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- Your content goes here: -->
+
+
+
+<!-- DO NOT EDIT BELOW THIS LINE! -->
+---
+
+Reviewer Resources:
+
+[Track Policies](POLICIES.md#event-checklist)

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -26,28 +26,40 @@ Our policies are not set-in-stone. They represent directions chosen at a point i
 
 ## Policy Descriptions
 
-### Prefer instance methods [[1](https://github.com/exercism/xjava/issues/177#issuecomment-261291741)]
+### Prefer instance methods
 
-Most (all?) exercises should be implemented in the form of instance methods since they contain "domain logic" and we (Exercism) want to encourage exemplary software.
+> Most (all?) exercises should be implemented in the form of instance methods since they contain "domain logic" and we (Exercism) want to encourage exemplary software.
 
-### Starter implementations [[1](https://github.com/exercism/xjava/issues/178)]
+References: [[1](https://github.com/exercism/xjava/issues/177#issuecomment-261291741)]
 
-- Exercises 1-10: provide stubs for all required methods.
-- Exercises 11-20: provide stubs for all methods required by the first test; comment-out the bodies of any tests that require non-stubbed methods.
-- Exercises 21+: provide no stubs, but mention any "interesting" interface aspects in the HINT.md file (which gets merged into the README.md for the exercise).
+### Starter implementations
 
-### Ignore noninitial tests [[1](https://github.com/exercism/xjava/issues/101#issuecomment-249349204)]
+> - Exercises 1-10: provide stubs for all required methods.
+> - Exercises 11-20: provide stubs for all methods required by the first test; comment-out the bodies of any tests that require non-stubbed methods.
+> - Exercises 21+: provide no stubs, but mention any "interesting" interface aspects in the HINT.md file (which gets merged into the README.md for the exercise).
 
-All but the first test in an exercise test suite should be annotated `@Ignore`.
+References: [[1](https://github.com/exercism/xjava/issues/178)]
 
-### Multiple file submissions [[1](https://github.com/exercism/xjava/issues/365#issuecomment-292533120)]
+### Ignore noninitial tests
 
-The first exercise in the track whose test suite mandates multiple solution files should be accompanied by a HINT.md file reminding the practitioner that the CLI supports multiple file submissions.
+> All but the first test in an exercise test suite should be annotated `@Ignore`.
 
-### Good first patches [[1](https://github.com/exercism/xjava/issues/220#issue-196447088)]
+References: [[1](https://github.com/exercism/xjava/issues/101#issuecomment-249349204)]
 
-Aim to keep 10-20 small and straightforward issues open at eny given time. Identify any such issues by applying the "Good first patch" label.
+### Multiple file submissions
 
-### Simple onboarding [[1](https://github.com/exercism/xjava/issues/395#issue-215734887)]
+> The first exercise in the track whose test suite mandates multiple solution files should be accompanied by a HINT.md file reminding the practitioner that the CLI supports multiple file submissions.
 
-The Installing Java instructions should seek to minimize the number of steps and the number of concepts a new-to-the-track practitioner needs to learn to get to coding.
+References: [[1](https://github.com/exercism/xjava/issues/365#issuecomment-292533120)]
+
+### Good first patches
+
+> Aim to keep 10-20 small and straightforward issues open at eny given time. Identify any such issues by applying the "Good first patch" label.
+
+References: [[1](https://github.com/exercism/xjava/issues/220#issue-196447088)]
+
+### Simple onboarding
+
+> The Installing Java instructions should seek to minimize the number of steps and the number of concepts a new-to-the-track practitioner needs to learn to get to coding.
+
+References: [[1](https://github.com/exercism/xjava/issues/395#issue-215734887)]

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -1,0 +1,53 @@
+# Track Policies
+
+This document:
+
+- describes all current track-wide policies; and
+- lists all policies that should be reviewed in response to any given track event.
+
+Maintainers should refer to this document each time they review a pull request.
+
+Our policies are not set-in-stone. They represent directions chosen at a point in time with the information/context available at that time. We actively encourage contributors to review and critique them. If you have read through the references that informed an existing policy and still feel it should be improved or removed, please comment and describe:
+
+1. your alternative perspective;
+2. your proposed changes; and
+3. how your proposal balances your own perspective with those already raised during prior discussions.
+
+## Event Checklist
+
+| Track Event | Policies to review |
+|:------------|:-----------------|
+| Exercise added | Prefer instance methods; Starter implementations; Ignore noninitial tests |
+| Exercise updated | Multiple file submissions; Ignore noninitial tests |
+| Track order updated | Multiple file submissions; Starter implementations |
+| New issue observed in track | Good first patches |
+| "Good first patch" issue completed | Good first patches |
+| Installing Java instructions updated | Simple onboarding |
+
+## Policy Descriptions
+
+### Prefer instance methods [[1](https://github.com/exercism/xjava/issues/177#issuecomment-261291741)]
+
+Most (all?) exercises should be implemented in the form of instance methods since they contain "domain logic" and we (Exercism) want to encourage exemplary software.
+
+### Starter implementations [[1](https://github.com/exercism/xjava/issues/178)]
+
+- Exercises 1-10: provide stubs for all required methods.
+- Exercises 11-20: provide stubs for all methods required by the first test; comment-out the bodies of any tests that require non-stubbed methods.
+- Exercises 21+: provide no stubs, but mention any "interesting" interface aspects in the HINT.md file (which gets merged into the README.md for the exercise).
+
+### Ignore noninitial tests [[1](https://github.com/exercism/xjava/issues/101#issuecomment-249349204)]
+
+All but the first test in an exercise test suite should be annotated `@Ignore`.
+
+### Multiple file submissions [[1](https://github.com/exercism/xjava/issues/365#issuecomment-292533120)]
+
+The first exercise in the track whose test suite mandates multiple solution files should be accompanied by a HINT.md file reminding the practitioner that the CLI supports multiple file submissions.
+
+### Good first patches [[1](https://github.com/exercism/xjava/issues/220#issue-196447088)]
+
+Aim to keep 10-20 small and straightforward issues open at eny given time. Identify any such issues by applying the "Good first patch" label.
+
+### Simple onboarding [[1](https://github.com/exercism/xjava/issues/395#issue-215734887)]
+
+The Installing Java instructions should seek to minimize the number of steps and the number of concepts a new-to-the-track practitioner needs to learn to get to coding.

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -17,12 +17,12 @@ Our policies are not set-in-stone. They represent directions chosen at a point i
 
 | Track Event | Policies to review |
 |:------------|:-----------------|
-| Exercise added | Prefer instance methods; Starter implementations; Ignore noninitial tests |
-| Exercise updated | Multiple file submissions; Ignore noninitial tests |
-| Track order updated | Multiple file submissions; Starter implementations |
-| New issue observed in track | Good first patches |
-| "Good first patch" issue completed | Good first patches |
-| Installing Java instructions updated | Simple onboarding |
+| Exercise added | [Prefer instance methods](#prefer-instance-methods); [Starter implementations](#starter-implementations); [Ignore noninitial tests](#ignore-noninitial-tests) |
+| Exercise updated | [Ignore noninitial tests](#ignore-noninitial-tests); [Multiple file submissions](#multiple-file-submissions) |
+| Track order updated | [Starter implementations](#starter-implementations); [Multiple file submissions](#multiple-file-submissions) |
+| New issue observed in track | [Good first patches](#good-first-patches) |
+| "Good first patch" issue completed | [Good first patches](#good-first-patches) |
+| Installing Java instructions updated | [Simple onboarding](#simple-onboarding) |
 
 ## Policy Descriptions
 


### PR DESCRIPTION
Closes #425.

I surveyed our policy label to seed this document, and also included a new PR template that links to the policy checklist (for ease of PR review).

Some of the relative links might not be quite right; it's hard to test that off-GitHub.

Feedback welcome!