### PR TITLE
difference-of-squares: synchronize tests with x-common

### DIFF
--- a/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
+++ b/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+/*
+ * version: 1.1.0
+ */
 public final class DifferenceOfSquaresCalculatorTest {
 
     private DifferenceOfSquaresCalculator calculator;

--- a/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
+++ b/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public final class DifferenceOfSquaresCalculatorTest {
+
     private DifferenceOfSquaresCalculator calculator;
 
     @Before
@@ -13,17 +14,17 @@ public final class DifferenceOfSquaresCalculatorTest {
     }
 
     @Test
-    public void testSquareOfSum5() {
-        final int expected = 225;
-        final int actual = calculator.computeSquareOfSumTo(5);
+    public void testSquareOfSum1() {
+        final int expected = 1;
+        final int actual = calculator.computeSquareOfSumTo(1);
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
-    public void testSquareOfSum10() {
-        final int expected = 3025;
-        final int actual = calculator.computeSquareOfSumTo(10);
+    public void testSquareOfSum5() {
+        final int expected = 225;
+        final int actual = calculator.computeSquareOfSumTo(5);
         assertEquals(expected, actual);
     }
 
@@ -37,17 +38,17 @@ public final class DifferenceOfSquaresCalculatorTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void testSumOfSquares5() {
-        final int expected = 55;
-        final int actual = calculator.computeSumOfSquaresTo(5);
+    public void testSumOfSquares1() {
+        final int expected = 1;
+        final int actual = calculator.computeSumOfSquaresTo(1);
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
-    public void testSumOfSquares10() {
-        final int expected = 385;
-        final int actual = calculator.computeSumOfSquaresTo(10);
+    public void testSumOfSquares5() {
+        final int expected = 55;
+        final int actual = calculator.computeSumOfSquaresTo(5);
         assertEquals(expected, actual);
     }
 
@@ -61,9 +62,9 @@ public final class DifferenceOfSquaresCalculatorTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void testDifferenceOfSquares0() {
+    public void testDifferenceOfSquares1() {
         final int expected = 0;
-        final int actual = calculator.computeDifferenceOfSquares(0);
+        final int actual = calculator.computeDifferenceOfSquares(1);
         assertEquals(expected, actual);
     }
 
@@ -72,14 +73,6 @@ public final class DifferenceOfSquaresCalculatorTest {
     public void testDifferenceOfSquares5() {
         final int expected = 170;
         final int actual = calculator.computeDifferenceOfSquares(5);
-        assertEquals(expected, actual);
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void testDifferenceOfSquares10() {
-        final int expected = 2640;
-        final int actual = calculator.computeDifferenceOfSquares(10);
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
<!-- Your content goes here: -->
The canonical test data of `difference-of-squares` has recently been [modified in x-common](https://github.com/exercism/x-common/pull/791). This pull request synchronizes the corresponding tests in the Java track with the generic data.

In short, the test inputs are changed to 1 and 5 and 10 for each of the three tested methods.
<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
