### PR TITLE
Parallelize unit tests

### DIFF
--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -10,6 +10,6 @@ bin/configlet .
 pushd exercises
 echo ""
 echo ">>> Running tests..."
-TERM=dumb ../gradlew check compileStarterSourceJava --continue
+TERM=dumb ../gradlew check compileStarterSourceJava --parallel --continue
 popd
 


### PR DESCRIPTION
<!-- Your content goes here: -->

~~**Includes #599, do not merge before that**~~

Adds `--parallel` flag to Gradle invocation used to run unit tests. Results in a ~2x speed increase for that portion of the build.

Before:

<img width="1065" alt="screen shot 2017-05-23 at 11 44 29 am" src="https://cloud.githubusercontent.com/assets/6463980/26350983/77edadbc-3fad-11e7-9768-0054532bd9fc.png">

After:

<img width="1065" alt="screen shot 2017-05-23 at 11 45 09 am" src="https://cloud.githubusercontent.com/assets/6463980/26351003/7ee7ed26-3fad-11e7-8d35-4840965acb4f.png">

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
