### PR TITLE
ocr-numbers: estimate difficulty, position

### DIFF
--- a/config.json
+++ b/config.json
@@ -271,11 +271,6 @@
       "topics": []
     },
     {
-      "slug": "rectangles",
-      "difficulty": 7,
-      "topics": []
-    },
-    {
       "slug": "meetup",
       "difficulty": 7,
       "topics": []
@@ -288,6 +283,16 @@
     {
       "slug": "clock",
       "difficulty": 7,
+      "topics": []
+    },
+    {
+      "slug": "ocr-numbers",
+      "difficulty": 8,
+      "topics": []
+    },
+    {
+      "slug": "rectangles",
+      "difficulty": 8,
       "topics": []
     },
     {
@@ -322,11 +327,6 @@
     },
     {
       "slug": "list-ops",
-      "difficulty": 1,
-      "topics": []
-    },
-    {
-      "slug": "ocr-numbers",
       "difficulty": 1,
       "topics": []
     },

--- a/exercises/ocr-numbers/src/example/java/OpticalCharacterReader.java
+++ b/exercises/ocr-numbers/src/example/java/OpticalCharacterReader.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 final class OpticalCharacterReader {
 
-    private static final int ROWS_PER_LINE  = 4;
+    private static final int ROWS_PER_LINE = 4;
 
     private static final int COLS_PER_SSD = 3;
 
@@ -56,9 +56,9 @@ final class OpticalCharacterReader {
                     "Number of input rows must be a positive multiple of " + ROWS_PER_LINE);
         }
 
-        final int inputColumnCount = input.get(0).length();
+        final int inputColCount = input.get(0).length();
 
-        if (inputColumnCount == 0 || inputColumnCount % 3 != 0) {
+        if (inputColCount == 0 || inputColCount % 3 != 0) {
             throw new IllegalArgumentException(
                     "Number of input columns must be a positive multiple of " + COLS_PER_SSD);
         }


### PR DESCRIPTION
<!-- Your content goes here: -->

Closes #341.

@FridaTveit I think this could be a 7 or an 8 but it is definitely easier than `rectangles`, which involves searching a grid for rectangles of arbitrary sizes and is currently also rated a 7. That might need to bump to an 8 or 9. The main difference is that in `ocr-numbers` we have an input grid of known-ish size and we're comparing against known digit representations; in `rectangles` we have arbitrarily-sized input (IIRC) and arbitrarily-sized rectangles.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
