### PR TITLE
Removing final from starter classes

### DIFF
--- a/exercises/acronym/src/main/java/Acronym.java
+++ b/exercises/acronym/src/main/java/Acronym.java
@@ -1,4 +1,4 @@
-final class Acronym {
+class Acronym {
 
     Acronym(String phrase) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");

--- a/exercises/all-your-base/src/main/java/BaseConverter.java
+++ b/exercises/all-your-base/src/main/java/BaseConverter.java
@@ -1,4 +1,4 @@
-final class BaseConverter {
+class BaseConverter {
 
 
 

--- a/exercises/bracket-push/src/main/java/BracketChecker.java
+++ b/exercises/bracket-push/src/main/java/BracketChecker.java
@@ -1,4 +1,4 @@
-final class BracketChecker {
+class BracketChecker {
 
 
 

--- a/exercises/change/src/main/java/ChangeCalculator.java
+++ b/exercises/change/src/main/java/ChangeCalculator.java
@@ -1,4 +1,4 @@
-final class ChangeCalculator {
+class ChangeCalculator {
 
 
 

--- a/exercises/diamond/src/main/java/DiamondPrinter.java
+++ b/exercises/diamond/src/main/java/DiamondPrinter.java
@@ -1,4 +1,4 @@
-final class DiamondPrinter {
+class DiamondPrinter {
 
 
 

--- a/exercises/flatten-array/src/main/java/Flattener.java
+++ b/exercises/flatten-array/src/main/java/Flattener.java
@@ -1,4 +1,4 @@
-final class Flattener {
+class Flattener {
 
 
 

--- a/exercises/luhn/src/main/java/LuhnValidator.java
+++ b/exercises/luhn/src/main/java/LuhnValidator.java
@@ -1,4 +1,4 @@
-final class LuhnValidator {
+class LuhnValidator {
 
     boolean isValid(String candidate) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");

--- a/exercises/minesweeper/src/main/java/MinesweeperBoard.java
+++ b/exercises/minesweeper/src/main/java/MinesweeperBoard.java
@@ -1,4 +1,4 @@
-public final class MinesweeperBoard {
+public class MinesweeperBoard {
 
 
 

--- a/exercises/ocr-numbers/src/main/java/OpticalCharacterReader.java
+++ b/exercises/ocr-numbers/src/main/java/OpticalCharacterReader.java
@@ -1,4 +1,4 @@
-final class OpticalCharacterReader {
+class OpticalCharacterReader {
 
 
 

--- a/exercises/perfect-numbers/src/main/java/NaturalNumber.java
+++ b/exercises/perfect-numbers/src/main/java/NaturalNumber.java
@@ -1,4 +1,4 @@
-final class NaturalNumber {
+class NaturalNumber {
 
 
 

--- a/exercises/queen-attack/src/main/java/BoardCoordinate.java
+++ b/exercises/queen-attack/src/main/java/BoardCoordinate.java
@@ -1,4 +1,4 @@
-public final class BoardCoordinate {
+public class BoardCoordinate {
 
 
 

--- a/exercises/queen-attack/src/main/java/QueenAttackCalculator.java
+++ b/exercises/queen-attack/src/main/java/QueenAttackCalculator.java
@@ -1,4 +1,4 @@
-public final class QueenAttackCalculator {
+public class QueenAttackCalculator {
 
 
 

--- a/exercises/rectangles/src/main/java/RectangleCounter.java
+++ b/exercises/rectangles/src/main/java/RectangleCounter.java
@@ -1,4 +1,4 @@
-final class RectangleCounter {
+class RectangleCounter {
 
 
 

--- a/exercises/robot-simulator/src/main/java/GridPosition.java
+++ b/exercises/robot-simulator/src/main/java/GridPosition.java
@@ -1,4 +1,4 @@
-final class GridPosition {
+class GridPosition {
 
     final int x;
 

--- a/exercises/robot-simulator/src/main/java/Robot.java
+++ b/exercises/robot-simulator/src/main/java/Robot.java
@@ -1,4 +1,4 @@
-final class Robot {
+class Robot {
 
 
 

--- a/exercises/saddle-points/src/main/java/Matrix.java
+++ b/exercises/saddle-points/src/main/java/Matrix.java
@@ -1,4 +1,4 @@
-final class Matrix {
+class Matrix {
 
 
 

--- a/exercises/saddle-points/src/main/java/MatrixCoordinate.java
+++ b/exercises/saddle-points/src/main/java/MatrixCoordinate.java
@@ -1,4 +1,4 @@
-final class MatrixCoordinate {
+class MatrixCoordinate {
 
   private final int row;
 

--- a/exercises/scrabble-score/src/main/java/Scrabble.java
+++ b/exercises/scrabble-score/src/main/java/Scrabble.java
@@ -1,4 +1,4 @@
-final class Scrabble {
+class Scrabble {
 
     Scrabble(String word) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");

--- a/exercises/secret-handshake/src/main/java/HandshakeCalculator.java
+++ b/exercises/secret-handshake/src/main/java/HandshakeCalculator.java
@@ -1,6 +1,6 @@
 import java.util.List;
 
-final class HandshakeCalculator {
+class HandshakeCalculator {
 
     List<Signal> calculateHandshake(int number) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");

--- a/exercises/sublist/src/main/java/RelationshipComputer.java
+++ b/exercises/sublist/src/main/java/RelationshipComputer.java
@@ -1,4 +1,4 @@
-final class RelationshipComputer<T> {
+class RelationshipComputer<T> {
 
 
 

--- a/exercises/wordy/src/main/java/WordProblemSolver.java
+++ b/exercises/wordy/src/main/java/WordProblemSolver.java
@@ -1,4 +1,4 @@
-final class WordProblemSolver {
+class WordProblemSolver {
 
 
 


### PR DESCRIPTION
<!-- Your content goes here: -->

Here's some work toward #642. Wasn't sure whether you wanted `final` removed from the `example` implementations also so I didn't do that yet, but I will gladly zip through those ones too if you want.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
